### PR TITLE
Add ability to turn off/on plugin functionality via keyboard shortcut

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1,26 +1,35 @@
 <idea-plugin version="2">
-  <id>org.nik.presentation-assistant</id>
-  <name>Presentation Assistant</name>
-  <version>0.9.5</version>
-  <vendor>Nikolay Chashnikov</vendor>
+    <id>org.nik.presentation-assistant</id>
+    <name>Presentation Assistant</name>
+    <version>0.9.6</version>
+    <vendor>Nikolay Chashnikov</vendor>
 
-  <description><![CDATA[This plugin shows name and Win/Mac shortcuts of any action you invoke (Settings | Presentation Assistant) ]]></description>
-  <change-notes><![CDATA[
+    <description>
+        <![CDATA[This plugin shows name and Win/Mac shortcuts of any action you invoke (Settings | Presentation Assistant) ]]></description>
+    <change-notes><![CDATA[
     <ul>
     <li>Keymaps used in notifications can be configured in Settings</li>
+    <li>Functionality of plugin can be toggle via keyboard shortcut. (Default Ctrl+Shift+P)</li>
     </ul>
 ]]></change-notes>
 
-  <idea-version since-build="107.105"/>
+    <idea-version since-build="107.105"/>
 
-  <depends>com.intellij.modules.lang</depends>
+    <depends>com.intellij.modules.lang</depends>
 
-  <application-components>
-      <component>
-          <implementation-class>org.nik.presentationAssistant.PresentationAssistant</implementation-class>
-      </component>
-  </application-components>
-  <extensions defaultExtensionNs="com.intellij">
-      <applicationConfigurable instance="org.nik.presentationAssistant.PresentationAssistantConfigurable"/>
-  </extensions>
+    <actions>
+        <action id="org.nik.presentationAssistant.PresentationAssistantToggle" text="Toggle PresentationAssistant" class="org.nik.presentationAssistant.actions.ShowHideAction"
+                description="Toggles PresentationAssistant on and off">
+            <keyboard-shortcut first-keystroke="control shift P" keymap="$default"/>
+        </action>
+    </actions>
+
+    <application-components>
+        <component>
+            <implementation-class>org.nik.presentationAssistant.PresentationAssistant</implementation-class>
+        </component>
+    </application-components>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationConfigurable instance="org.nik.presentationAssistant.PresentationAssistantConfigurable"/>
+    </extensions>
 </idea-plugin>

--- a/src/ShowHideAction.kt
+++ b/src/ShowHideAction.kt
@@ -1,0 +1,22 @@
+/**
+ * Created by IntelliJ IDEA.
+ * Author: Vladimir Kravets
+ * E-Mail: vova.kravets@gmail.com
+ * Date: 7/2/14
+ * Time: 8:07 PM
+ */
+
+package org.nik.presentationAssistant.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import org.nik.presentationAssistant.getPresentationAssistant
+
+public class ShowHideAction : AnAction() {
+
+    override fun actionPerformed(p0: AnActionEvent?) {
+        val presentationAssistant = getPresentationAssistant()
+        presentationAssistant.setShowActionsDescriptions(!presentationAssistant.configuration.showActionDescriptions)
+    }
+
+}


### PR DESCRIPTION
Add ability to turn off/on plugin functionality via keyboard shortcut

Need think about MAC default shortcut, but in any case we can control 
plugin via one keyboard shortcut.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chashnikov/intellij-presentation-assistant/9)
<!-- Reviewable:end -->
