### PR TITLE
Dirty fix for first shortcut slow-down + better display for popup

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IU-129.1359" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/src/Keymaps.kt
+++ b/src/Keymaps.kt
@@ -11,8 +11,8 @@ private val winKeymap = KeymapManager.getInstance()!!.getKeymap(KeymapKind.WIN.d
 private val macKeymap = KeymapManager.getInstance()!!.getKeymap(KeymapKind.MAC.defaultKeymapName);
 
 enum class KeymapKind(val displayName: String, val defaultKeymapName: String) {
-    WIN: KeymapKind("Win/Linux", "\$default")
-    MAC: KeymapKind("Mac", "Mac OS X 10.5+")
+    WIN("Win/Linux", "\$default"),
+    MAC("Mac", "Mac OS X 10.5+");
 
     fun getAlternativeKind() = when (this) {
         WIN -> MAC

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>org.nik.presentation-assistant</id>
   <name>Presentation Assistant</name>
-  <version>0.9.5</version>
+  <version>0.9.7</version>
   <vendor>Nikolay Chashnikov</vendor>
 
   <description><![CDATA[This plugin shows name and Win/Mac shortcuts of any action you invoke (Settings | Presentation Assistant) ]]></description>

--- a/src/MacKeyStrokePresentation.kt
+++ b/src/MacKeyStrokePresentation.kt
@@ -12,13 +12,13 @@ import java.awt.GraphicsEnvironment
 
 val LOG = Logger.getInstance("#org.nik.presentationAssistant.MacKeyStrokePresentation")
 
-val macKeyStokesFont by Delegates.lazy {
+val macKeyStokesFont by lazy {
     GraphicsEnvironment.getLocalGraphicsEnvironment()!!.getAllFonts()!!
             .minBy { getNonDisplayableMacSymbols(it).size }
 }
 
 fun getNonDisplayableMacSymbols(font: Font) =
-        javaClass<MacKeymapUtil>().getDeclaredFields()
-                .filter { it.getType() == javaClass<String>() && it.getName() != "APPLE"
+        MacKeymapUtil::class.java.getDeclaredFields()
+                .filter { it.getType() == String::class.java && it.getName() != "APPLE"
                           && font.canDisplayUpTo(it.get(null) as String) != -1 }
                 .map { it.getName()!! }

--- a/src/PresentationAssistant.kt
+++ b/src/PresentationAssistant.kt
@@ -29,14 +29,14 @@ public class PresentationAssistantState {
 }
 
 //todo[nik] report kotlin bug: if PersistentStateComponent is implemented directly IDEA is unable to obtain state class
-State(name = "PresentationAssistant", storages = array(Storage(file = "${StoragePathMacros.APP_CONFIG}/presentation-assistant.xml")))
+@State(name = "PresentationAssistant", storages = arrayOf(Storage(file = "${StoragePathMacros.APP_CONFIG}/presentation-assistant.xml")))
 public class PresentationAssistant : PresentationAssistantBase() {
     val configuration = PresentationAssistantState()
     var presenter: ShortcutPresenter? = null
 
     override fun getState() = configuration
     override fun loadState(p0: PresentationAssistantState?) {
-        XmlSerializerUtil.copyBean(p0, configuration)
+        XmlSerializerUtil.copyBean(p0!!, configuration)
     }
     override fun initComponent() {
         if (configuration.showActionDescriptions) {
@@ -64,16 +64,17 @@ public class PresentationAssistant : PresentationAssistantBase() {
     }
 }
 
-fun getPresentationAssistant(): PresentationAssistant = ApplicationManager.getApplication()!!.getComponent(javaClass<PresentationAssistant>())!!
+fun getPresentationAssistant(): PresentationAssistant = ApplicationManager.getApplication()!!.getComponent(PresentationAssistant::class.java)!!
 
 public class KeymapDescriptionPanel {
     val combobox : ComboBox
     val text = JTextField(10)
     val mainPanel: JPanel
+    init
     {
         combobox = ComboBox(KeymapManagerEx.getInstanceEx()!!.getAllKeymaps()!!)
         combobox.setRenderer(object: ListCellRendererWrapper<Keymap>() {
-            override fun customize(jList: JList?, t: Keymap?, i: Int, b: Boolean, b1: Boolean) {
+            override fun customize(jList: JList<*>?, t: Keymap?, i: Int, b: Boolean, b1: Boolean) {
                 setText(t?.getPresentableName() ?: "")
             }
         })
@@ -104,6 +105,7 @@ public class PresentationAssistantConfigurable : Configurable, SearchableConfigu
     val altKeymapPanel = KeymapDescriptionPanel()
     val fontSizeField = JTextField(5)
     val mainPanel: JPanel
+    init
     {
         val formBuilder = FormBuilder.createFormBuilder()!!
                            .addComponent(showActionsCheckbox)!!

--- a/src/WinKeyStrokePresentation.kt
+++ b/src/WinKeyStrokePresentation.kt
@@ -9,26 +9,26 @@ import kotlin.properties.Delegates
 import java.awt.event.KeyEvent
 import java.lang.reflect.Modifier
 
-val inputEventMaskFieldNames by Delegates.lazy {
-    javaClass<InputEvent>().getFields()
+val inputEventMaskFieldNames by lazy {
+    InputEvent::class.java.getFields()
             .filter { it.getName()!!.endsWith("_MASK") && !it.getName()!!.endsWith("_DOWN_MASK")
                       && !it.getName()!!.startsWith("BUTTON")
                       && Modifier.isStatic(it.getModifiers()) && it.get(null) is Int}
-            .map { Pair(fieldNameToPresentableName(it.getName()!!.trimTrailing("_MASK")), it.get(null) as Int)}
+            .map { Pair(fieldNameToPresentableName(it.getName()!!.removeSuffix("_MASK")), it.get(null) as Int)}
 }
 
 fun getWinModifiersText(modifiers: Int) =
         inputEventMaskFieldNames
                 .filter { modifiers and (it.second) != 0}
                 .map { it.first }
-                .makeString("+")
+                .joinToString("+")
 
-val keyEventFieldNames by Delegates.lazy {
-    javaClass<KeyEvent>().getFields()
+val keyEventFieldNames by lazy {
+    KeyEvent::class.java.getFields()
             .filter { it.getName()!!.startsWith("VK_") && Modifier.isStatic(it.getModifiers()) && it.get(null) is Int}
-            .map { Pair(fieldNameToPresentableName(it.getName()!!.trimLeading("VK_")), it.get(null) as Int)}
+            .map { Pair(fieldNameToPresentableName(it.getName()!!.removePrefix("VK_")), it.get(null) as Int)}
             .groupBy { it.second }
-            .mapValues { it.value.first!!.first }
+            .mapValues { it.value.first()!!.first }
 }
 
 fun getWinKeyText(key: Int) =
@@ -40,9 +40,9 @@ fun getWinKeyText(key: Int) =
         KeyEvent.VK_SUBTRACT -> "NumPad -"
         KeyEvent.VK_DECIMAL -> "NumPad ."
         KeyEvent.VK_DIVIDE -> "NumPad /"
-        in keyEventFieldNames.keySet() -> keyEventFieldNames[key]
+        in keyEventFieldNames.keys -> keyEventFieldNames[key]
         else -> "Unknown key 0x${Integer.toHexString(key)}"
     }
         
 
-fun fieldNameToPresentableName(name: String) = name.split('_').map { StringUtil.capitalize(it.toLowerCase()) }.makeString(" ")
+fun fieldNameToPresentableName(name: String) = name.split('_').map { StringUtil.capitalize(it.toLowerCase()) }.joinToString(" ")


### PR DESCRIPTION
Notes:

1. A lot of changes for new Kotlin version cause I could not compile the old one
2. Not sure with the shortcuts on Windows, but: what we need is to get rid of loading all fonts on UI thread, cause it's really bad. May be we should load it in some background thread or better - on app start and then save somewhere. 
3. I'm not against the round corners, but I guess more simple approach will be much better for displaying the popup. Just because it's flat. 
Round corners and mask cause various problems when using it on Mac - for example, we still have not-rounded corners for first shortcut. 
Next, when round-corners appear - it still looks bad. No round-corners seems to be better for me. 

