### PR TITLE
Dumb aware toggle action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.idea/modules/
 /.idea/inspectionProfiles/
 /.idea/scopes/
+/build
+/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.intellij' version "0.1.10"
+    id 'org.jetbrains.intellij' version "0.2.5"
 }
 
 allprojects {
@@ -21,6 +21,13 @@ allprojects {
     apply plugin: 'kotlin'
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
+
+    compileKotlin {
+        kotlinOptions {
+            languageVersion = '1.1'
+            apiVersion = '1.0'
+        }
+    }
 
     sourceSets {
         main {
@@ -35,7 +42,7 @@ allprojects {
         version ideaVersion
         pluginName 'Presentation Assistant'
         updateSinceUntilBuild false
-        publish {
+        publishPlugin {
             username publishUsername
             password publishPassword
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.9.10
+version = 0.9.11
 ideaVersion = 2016.3.5
 javaVersion = 1.8
 kotlinVersion = 1.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version = 0.9.10
-ideaVersion = 2016.2.4
+ideaVersion = 2016.3.5
 javaVersion = 1.8
-kotlinVersion = 1.0.4
+kotlinVersion = 1.1.1
 
 publishUsername=user
 publishPassword=password

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 29 20:47:38 MSK 2016
+#Mon Mar 20 11:37:24 MSK 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip

--- a/src/org/nik/presentationAssistant/ShowActionDescriptionsToggleAction.kt
+++ b/src/org/nik/presentationAssistant/ShowActionDescriptionsToggleAction.kt
@@ -17,11 +17,12 @@ package org.nik.presentationAssistant
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.project.DumbAware
 
 /**
  * @author nik
  */
-class ShowActionDescriptionsToggleAction : ToggleAction("Descriptions of Actions") {
+class ShowActionDescriptionsToggleAction : ToggleAction("Descriptions of Actions"), DumbAware {
     override fun isSelected(e: AnActionEvent) = getPresentationAssistant().configuration.showActionDescriptions
 
     override fun setSelected(e: AnActionEvent, state: Boolean) {


### PR DESCRIPTION
Hi!

This makes **Toggle Descriptions of Actions** dumb aware: it's useful to be able to toggle Presentation Assistant while IDEA is updating indices. 

Along the way I've updated Kotlin, IDEA, gradle and intellij-gradle dependencies.