### PR TITLE
Add margin field

### DIFF
--- a/src/org/nik/presentationAssistant/ActionInfoPanel.kt
+++ b/src/org/nik/presentationAssistant/ActionInfoPanel.kt
@@ -144,13 +144,13 @@ class ActionInfoPanel(project: Project, textFragments: List<Pair<String, Font?>>
         val visibleRect = ideFrame.component.visibleRect
         val popupSize = preferredSize
         val x = when (pluginConfiguration.horizontalAlignment) {
-            PopupHorizontalAlignment.LEFT -> visibleRect.x + 10
+            PopupHorizontalAlignment.LEFT -> visibleRect.x + pluginConfiguration.margin
             PopupHorizontalAlignment.CENTER -> visibleRect.x + (visibleRect.width - popupSize.width) / 2
-            PopupHorizontalAlignment.RIGHT -> visibleRect.x + visibleRect.width - popupSize.width - 10
+            PopupHorizontalAlignment.RIGHT -> visibleRect.x + visibleRect.width - popupSize.width - pluginConfiguration.margin
         }
         val y = when (pluginConfiguration.verticalAlignment) {
-            PopupVerticalAlignment.TOP -> visibleRect.y + 10
-            PopupVerticalAlignment.BOTTOM -> visibleRect.y + visibleRect.height - popupSize.height - statusBarHeight - 5
+            PopupVerticalAlignment.TOP -> visibleRect.y + pluginConfiguration.margin
+            PopupVerticalAlignment.BOTTOM -> visibleRect.y + visibleRect.height - popupSize.height - statusBarHeight - pluginConfiguration.margin
         }
         return RelativePoint(ideFrame.component, Point(x, y))
     }

--- a/src/org/nik/presentationAssistant/PresentationAssistant.kt
+++ b/src/org/nik/presentationAssistant/PresentationAssistant.kt
@@ -50,6 +50,7 @@ class PresentationAssistantState {
     var alternativeKeymap = getDefaultAlternativeKeymap()
     var horizontalAlignment = PopupHorizontalAlignment.CENTER
     var verticalAlignment = PopupVerticalAlignment.BOTTOM
+    var margin = 5
 }
 
 enum class PopupHorizontalAlignment { LEFT, CENTER, RIGHT }
@@ -150,6 +151,8 @@ class PresentationAssistantConfigurable : Configurable, SearchableConfigurable {
     private val hideDelayField = JTextField(5)
     private val horizontalAlignmentButtons = PopupHorizontalAlignment.values().associate { it to JRadioButton(it.name.toLowerCase().capitalize()) }
     private val verticalAlignmentButtons = PopupVerticalAlignment.values().associate { it to JRadioButton(it.name.toLowerCase().capitalize()) }
+    private val marginField = JTextField(5)
+
     private val mainPanel: JPanel
     init
     {
@@ -171,6 +174,7 @@ class PresentationAssistantConfigurable : Configurable, SearchableConfigurable {
                            .addLabeledComponent("&Display duration (in ms):", hideDelayField)
                            .addLabeledComponent("Horizontal alignment:", horizontalAlignmentPanel, 0)
                            .addLabeledComponent("Vertical alignment:", verticalAlignmentPanel, 0)
+                           .addLabeledComponent("Margin:", marginField, 0)
                            .addVerticalGap(10)
                            .addLabeledComponent("Main Keymap:", mainKeymapPanel.mainPanel, true)
                            .addLabeledComponent(showAltKeymap, altKeymapPanel.mainPanel, true)
@@ -197,6 +201,7 @@ class PresentationAssistantConfigurable : Configurable, SearchableConfigurable {
                                 || configuration.configuration.alternativeKeymap != getAlternativeKeymap()
                                 || !horizontalAlignmentButtons[configuration.configuration.horizontalAlignment]!!.isSelected
                                 || !verticalAlignmentButtons[configuration.configuration.verticalAlignment]!!.isSelected
+                                || isDigitsOnly(marginField.text) && (marginField.text != configuration.configuration.margin.toString())
 
     private fun getAlternativeKeymap() = if (showAltKeymap.isSelected) altKeymapPanel.getDescription() else null
 
@@ -207,6 +212,7 @@ class PresentationAssistantConfigurable : Configurable, SearchableConfigurable {
         configuration.configuration.alternativeKeymap = getAlternativeKeymap()
         configuration.configuration.horizontalAlignment = horizontalAlignmentButtons.entries.find { it.value.isSelected }!!.key
         configuration.configuration.verticalAlignment = verticalAlignmentButtons.entries.find { it.value.isSelected }!!.key
+        configuration.configuration.margin = marginField.text.trim().toInt()
     }
 
     override fun reset() {
@@ -217,6 +223,7 @@ class PresentationAssistantConfigurable : Configurable, SearchableConfigurable {
         altKeymapPanel.reset(configuration.configuration.alternativeKeymap ?: KeymapDescription("", ""))
         horizontalAlignmentButtons.forEach { value, button -> button.isSelected = configuration.configuration.horizontalAlignment == value }
         verticalAlignmentButtons.forEach { value, button -> button.isSelected = configuration.configuration.verticalAlignment == value }
+        marginField.text = configuration.configuration.margin.toString()
         updatePanels()
     }
 


### PR DESCRIPTION
Typical case when making a screenshot is to capture a specific part of the ide and have PA visible. Right now if this area is far from bottom, I need to resize the whole window. With this modification I can leave it as is and just tune the space between IDE window bottom and PA hint. 